### PR TITLE
Remove unnecessary slash in output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,7 @@ export function markdownItImageSize(md: markdownIt): void {
     const dimensionsAttributes =
       width && height ? ` width="${width}" height="${height}"` : "";
 
-    return `<img src="${imageUrl}" alt="${caption}"${dimensionsAttributes} ${
-      otherAttributes ? otherAttributes + " " : ""
-    }/>`;
+    return `<img src="${imageUrl}" alt="${caption}"${dimensionsAttributes} ${otherAttributes}>`;
   };
 }
 


### PR DESCRIPTION
The trailing slash for void elements in HTML is optional and has no effect.