### PR TITLE
Support images with no explicit protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-it-image-size",
-  "version": "13.1.1",
+  "version": "13.2.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-it-image-size",
-      "version": "13.1.1",
+      "version": "13.2.0-0",
       "license": "ISC",
       "dependencies": {
         "image-size": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-it-image-size",
-  "version": "13.2.0-0",
+  "version": "13.2.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-it-image-size",
-      "version": "13.2.0-0",
+      "version": "13.2.0-1",
       "license": "ISC",
       "dependencies": {
         "image-size": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-image-size",
-  "version": "13.2.0-0",
+  "version": "13.2.0-1",
   "description": "Adds width and height to image tags rendered by markdown-it",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-image-size",
-  "version": "13.1.1",
+  "version": "13.2.0-0",
   "description": "Adds width and height to image tags rendered by markdown-it",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ export function markdownItImageSize(md: markdownIt): void {
     const otherAttributes = generateAttributes(md, token);
 
     const isExternalImage =
-      imageUrl.startsWith("http://") || imageUrl.startsWith("https://");
+      imageUrl.startsWith("http://") ||
+      imageUrl.startsWith("https://") ||
+      imageUrl.startsWith("//");
+
     const isLocalAbsoluteUrl = imageUrl.startsWith("/");
 
     const { width, height } = isExternalImage
@@ -68,7 +71,9 @@ function getImageDimensionsFromExternalImage(imageUrl: string): {
   width: number;
   height: number;
 } {
-  const response = fetch(imageUrl);
+  const isMissingProtocol = imageUrl.startsWith("//");
+
+  const response = fetch(isMissingProtocol ? `https:${imageUrl}` : imageUrl);
   const buffer = response.buffer();
   const { width, height } = imageSize(buffer);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -48,4 +48,20 @@ describe(markdownItImageSize.name, () => {
 
     expect(actual).toBe(expected);
   });
+
+  it("should render external images with no explicit protocol with attributes for width and height", () => {
+    const markdownRenderer = new MarkdownIt().use(markdownItImageSize);
+
+    const imageUrl =
+      "//images.unsplash.com/photo-1577811037855-935237616bac?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=2167&q=80";
+    const markdown = `![](${imageUrl})`;
+
+    const imageWidth = 2167;
+    const imageHeight = 1625;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"></p>\n`;
+    const actual = markdownRenderer.render(markdown);
+
+    expect(actual).toBe(expected);
+  });
 });


### PR DESCRIPTION
Fixes #399

This PR is installable with `npm i markdown-it-image-size@next`.