### PR TITLE
feat: option `overwriteAttrs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Automatically adds `width` and `height` attributes to `img` tags rendered by [markdown-it](https://github.com/markdown-it/markdown-it/).
 Supports both local and remote images.
 
+If you'd rather set image sizes manually, check out [@mdit/plugin-img-size](https://mdit-plugins.github.io/img-size.html).
+
 ## Why
 
 Browsers use the `width` and `height` attributes to [determine aspect ratios of images](https://developer.mozilla.org/en-US/docs/Web/Media/images/aspect_ratio_mapping). If the attributes are set, the browser can reserve space for the image even though it's not finished loading yet, thus preventing [cumulative layout shifts](https://web.dev/cls/) after images load.
@@ -59,6 +61,33 @@ const mdRenderer = MarkdownIt();
 mdRenderer.use(markdownItImageSize, {
   cache: false,
 });
+```
+
+### Option: `overwriteAttrs`
+
+Type: `boolean`
+Default: `false`
+
+The `overwriteAttrs` option lets you overwrite existing `width` and `height` attributes on `img` tags.
+This is useful when using another plugin which sets the attributes, such as [@mdit/plugin-img-size](https://mdit-plugins.github.io/img-size.html).
+
+```js
+const MarkdownIt = require("markdown-it");
+const { markdownItImageSize } = require("markdown-it-image-size");
+const { imgSize } = require("@mdit/plugin-img-size");
+
+const mdRenderer = MarkdownIt();
+mdRenderer
+  .use(imgSize)
+  .use(markdownItImageSize, {
+    overwriteAttrs: true,
+  });
+
+const html = mdRenderer.render(`![alt text](/path/to/image.jpg =100x200)`);
+console.log(html);
+
+// The attributes are overwritten with the correct dimensions (350x700).
+// <p><img src="/path/to/image.jpg" alt="alt text" width="350" height="700"></p>
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,6 +1029,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mdit/plugin-img-size": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-img-size/-/plugin-img-size-0.14.0.tgz",
+      "integrity": "sha512-A+HyWSSTXW318Ly48xOf4XnKW4xTstXewoY87cSXjw0eGO/rR50n4golihEJ9ixxUlJ/E8zpGCu454cOOBriKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "markdown-it": "^14.1.0"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9433,6 +9454,7 @@
         "sync-fetch": "^0.5.2"
       },
       "devDependencies": {
+        "@mdit/plugin-img-size": "^0.14.0",
         "@release-it/conventional-changelog": "^9.0.3",
         "@rollup/plugin-commonjs": "^28.0.2",
         "@rollup/plugin-node-resolve": "^16.0.0",

--- a/packages/markdown-it-image-size/README.md
+++ b/packages/markdown-it-image-size/README.md
@@ -5,6 +5,8 @@
 Automatically adds `width` and `height` attributes to `img` tags rendered by [markdown-it](https://github.com/markdown-it/markdown-it/).
 Supports both local and remote images.
 
+If you'd rather set image sizes manually, check out [@mdit/plugin-img-size](https://mdit-plugins.github.io/img-size.html).
+
 ## Why
 
 Browsers use the `width` and `height` attributes to [determine aspect ratios of images](https://developer.mozilla.org/en-US/docs/Web/Media/images/aspect_ratio_mapping). If the attributes are set, the browser can reserve space for the image even though it's not finished loading yet, thus preventing [cumulative layout shifts](https://web.dev/cls/) after images load.
@@ -60,3 +62,53 @@ mdRenderer.use(markdownItImageSize, {
   cache: false,
 });
 ```
+
+### Option: `overwriteAttrs`
+
+Type: `boolean`
+Default: `false`
+
+The `overwriteAttrs` option lets you overwrite existing `width` and `height` attributes on `img` tags.
+This is useful when using another plugin which sets the attributes, such as [@mdit/plugin-img-size](https://mdit-plugins.github.io/img-size.html).
+
+```js
+const MarkdownIt = require("markdown-it");
+const { markdownItImageSize } = require("markdown-it-image-size");
+const { imgSize } = require("@mdit/plugin-img-size");
+
+const mdRenderer = MarkdownIt();
+mdRenderer
+  .use(imgSize)
+  .use(markdownItImageSize, {
+    overwriteAttrs: true,
+  });
+
+const html = mdRenderer.render(`![alt text](/path/to/image.jpg =100x200)`);
+console.log(html);
+
+// The attributes are overwritten with the correct dimensions (350x700).
+// <p><img src="/path/to/image.jpg" alt="alt text" width="350" height="700"></p>
+```
+
+## Development
+
+This project uses tsup for bundling and Vitest for testing.
+It currently supports Node.js 16 and up.
+To get started, fork the repository and run the following commands:
+
+```bash
+# Install dependencies
+npm install
+
+# Build the project
+npm run build
+
+# Run tests
+npm test
+
+# Lint and format
+npm run lint:fix
+```
+
+> [!NOTE]
+> The unit tests run on the build output, so make sure to run `npm run build` before running the tests if you have made changes to the source code.

--- a/packages/markdown-it-image-size/package.json
+++ b/packages/markdown-it-image-size/package.json
@@ -21,8 +21,10 @@
   "types": "dist/index.d.ts",
   "files": ["dist", "README.md", "CHANGELOG.md"],
   "scripts": {
-    "build": "npm run clean && npm run compile",
-    "clean": "rimraf dist",
+    "build": "npm run clean:output && npm run compile",
+    "clean": "npm run clean:cache && npm run clean:output",
+    "clean:cache": "rimraf node_modules/markdown-it-image-size/.cache",
+    "clean:output": "rimraf dist",
     "compile": "tsup ./src/index.ts --format cjs --dts --minify --legacy-output dist/markdown-it-image-size",
     "publish-to-npm": "release-it",
     "test": "vitest run",
@@ -35,6 +37,7 @@
     "sync-fetch": "^0.5.2"
   },
   "devDependencies": {
+    "@mdit/plugin-img-size": "^0.14.0",
     "@release-it/conventional-changelog": "^9.0.3",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",

--- a/packages/markdown-it-image-size/test/option-cache.test.ts
+++ b/packages/markdown-it-image-size/test/option-cache.test.ts
@@ -38,7 +38,7 @@ describe("option cache", () => {
   it("should support using file system caching", () => {
     const spy = vi.spyOn(getImageDimensionsModule, "getImageDimensions");
 
-    const cacheFile = `${crypto.randomUUID()}.json`;
+    const cacheFile = "file-system-cache-test.json";
     const markdownRenderer = new MarkdownIt().use(markdownItImageSize, {
       _cacheFile: cacheFile,
     });

--- a/packages/markdown-it-image-size/test/option-cache.test.ts
+++ b/packages/markdown-it-image-size/test/option-cache.test.ts
@@ -1,0 +1,102 @@
+import MarkdownIt from "markdown-it";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { markdownItImageSize } from "../src";
+import * as getImageDimensionsModule from "../src/get-image-dimensions";
+import { clearCache } from "./test-utils";
+
+const cacheFile = "cache-3.json";
+
+describe("option cache", () => {
+  let markdownRenderer: MarkdownIt;
+
+  beforeEach(() => {
+    clearCache(cacheFile);
+
+    markdownRenderer = new MarkdownIt().use(markdownItImageSize, {
+      cache: true,
+      _cacheFile: cacheFile,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should work with cache", () => {
+    const imageUrl = "/test/test-assets/image1.jpg";
+    const markdown = `![](${imageUrl}) ![](${imageUrl})`;
+
+    const imageWidth = 4032;
+    const imageHeight = 3024;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"> <img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"></p>\n`;
+    const actual = markdownRenderer.render(markdown);
+
+    expect(actual).toBe(expected);
+  });
+
+  it("should support using file system caching", () => {
+    const spy = vi.spyOn(getImageDimensionsModule, "getImageDimensions");
+
+    const cacheFile = `${crypto.randomUUID()}.json`;
+    const markdownRenderer = new MarkdownIt().use(markdownItImageSize, {
+      _cacheFile: cacheFile,
+    });
+
+    const imageUrl = "/test/test-assets/image1.jpg";
+    const markdown = `![](${imageUrl})`;
+
+    const imageWidth = 4032;
+    const imageHeight = 3024;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"></p>\n`;
+    const fresh = markdownRenderer.render(markdown);
+
+    const markdownRenderer2 = new MarkdownIt().use(markdownItImageSize, {
+      _cacheFile: cacheFile,
+    });
+    const cached = markdownRenderer2.render(markdown);
+
+    expect(cached).toEqual(expected);
+    expect(cached).toEqual(fresh);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should support disabling caching", () => {
+    const spy = vi.spyOn(getImageDimensionsModule, "getImageDimensions");
+
+    const markdownRenderer = new MarkdownIt().use(markdownItImageSize, {
+      cache: false,
+    });
+
+    const imageUrl = "/test/test-assets/image1.jpg";
+    const markdown = `![](${imageUrl})`;
+
+    const imageWidth = 4032;
+    const imageHeight = 3024;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"></p>\n`;
+    const actual = markdownRenderer.render(markdown);
+    markdownRenderer.render(markdown);
+
+    expect(actual).toBe(expected);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should work without cache", () => {
+    const markdownRenderer = new MarkdownIt().use(markdownItImageSize, {
+      cache: false,
+    });
+
+    const imageUrl = "/test/test-assets/image1.jpg";
+    const markdown = `![](${imageUrl}) ![](${imageUrl})`;
+
+    const imageWidth = 4032;
+    const imageHeight = 3024;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"> <img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"></p>\n`;
+    const actual = markdownRenderer.render(markdown);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/markdown-it-image-size/test/option-overwrite-attrs.test.ts
+++ b/packages/markdown-it-image-size/test/option-overwrite-attrs.test.ts
@@ -1,0 +1,49 @@
+import { imgSize as mditPluginImgSize } from "@mdit/plugin-img-size";
+import MarkdownIt from "markdown-it";
+import { beforeEach, describe, expect, it } from "vitest";
+import { markdownItImageSize } from "../src";
+import { clearCache } from "./test-utils";
+
+const cacheFile = "cache-4.json";
+
+describe("option overwriteAttrs", () => {
+  beforeEach(() => {
+    clearCache(cacheFile);
+  });
+
+  it("should overwrite width and height attributes if they are already present", () => {
+    const markdownRenderer = new MarkdownIt()
+      .use(mditPluginImgSize) // Use @mdit/plugin-img-size first to add width and height attributes
+      .use(markdownItImageSize, {
+        overwriteAttrs: true,
+        _cacheFile: cacheFile,
+      });
+
+    const imageUrl = "/test/test-assets/image1.jpg";
+    const markdown = `![](${imageUrl} =100x200)`;
+
+    const imageWidth = 4032;
+    const imageHeight = 3024;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"></p>\n`;
+    const actual = markdownRenderer.render(markdown);
+
+    expect(actual).toBe(expected);
+  });
+
+  it("should not overwrite width and height attributes if they are already present", () => {
+    const markdownRenderer = new MarkdownIt()
+      .use(mditPluginImgSize) // Use @mdit/plugin-img-size first to add width and height attributes
+      .use(markdownItImageSize, {
+        _cacheFile: cacheFile,
+      });
+
+    const imageUrl = "/test/test-assets/image1.jpg";
+    const markdown = `![](${imageUrl} =100x200)`;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="100" height="200"></p>\n`;
+    const actual = markdownRenderer.render(markdown);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/markdown-it-image-size/test/option-public-dir.test.ts
+++ b/packages/markdown-it-image-size/test/option-public-dir.test.ts
@@ -1,0 +1,30 @@
+import MarkdownIt from "markdown-it";
+import { beforeEach, describe, expect, it } from "vitest";
+import { markdownItImageSize } from "../src";
+import { clearCache } from "./test-utils";
+
+const cacheFile = "cache-5.json";
+
+describe("option publicDir", () => {
+  beforeEach(() => {
+    clearCache(cacheFile);
+  });
+
+  it("should support a publicDir option", () => {
+    const markdownRenderer = new MarkdownIt().use(markdownItImageSize, {
+      publicDir: "test",
+      _cacheFile: cacheFile,
+    });
+
+    const imageUrl = "/test-assets/image1.jpg";
+    const markdown = `![](${imageUrl})`;
+
+    const imageWidth = 4032;
+    const imageHeight = 3024;
+
+    const expected = `<p><img src="${imageUrl}" alt="" width="${imageWidth}" height="${imageHeight}"></p>\n`;
+    const actual = markdownRenderer.render(markdown);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/markdown-it-image-size/test/package.test.ts
+++ b/packages/markdown-it-image-size/test/package.test.ts
@@ -1,11 +1,22 @@
 import MarkdownIt from "markdown-it";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { markdownItImageSize } from "..";
+import { clearCache } from "./test-utils";
+
+const cacheFile = "cache-6.json";
 
 describe(markdownItImageSize.name, () => {
-  it("should render local images with attributes for width and height", () => {
-    const markdownRenderer = new MarkdownIt().use(markdownItImageSize);
+  let markdownRenderer: MarkdownIt;
 
+  beforeEach(() => {
+    clearCache(cacheFile);
+
+    markdownRenderer = new MarkdownIt().use(markdownItImageSize, {
+      _cacheFile: cacheFile,
+    });
+  });
+
+  it("should render local images with attributes for width and height", () => {
     const imageUrl = "/test/test-assets/image1.jpg";
     const markdown = `![](${imageUrl})`;
 
@@ -19,8 +30,6 @@ describe(markdownItImageSize.name, () => {
   });
 
   it("should render local images with attributes for width and height, and title", () => {
-    const markdownRenderer = new MarkdownIt().use(markdownItImageSize);
-
     const imageUrl = "/test/test-assets/image1.jpg";
     const markdown = `![](${imageUrl} "title")`;
 
@@ -34,8 +43,6 @@ describe(markdownItImageSize.name, () => {
   });
 
   it("should render external images with attributes for width and height", () => {
-    const markdownRenderer = new MarkdownIt().use(markdownItImageSize);
-
     const imageUrl =
       "https://images.unsplash.com/photo-1577811037855-935237616bac?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=2167&q=80";
     const markdown = `![](${imageUrl})`;

--- a/packages/markdown-it-image-size/test/test-utils.ts
+++ b/packages/markdown-it-image-size/test/test-utils.ts
@@ -1,0 +1,11 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CACHE_DIR } from "../src";
+
+export const clearCache = (cacheFile: string) => {
+  // Clear cache
+  const cachePath = path.join(CACHE_DIR, cacheFile);
+  if (fs.existsSync(cachePath)) {
+    fs.rmSync(cachePath, { force: true });
+  }
+};


### PR DESCRIPTION
This PR adds the new `overwriteAttrs` boolean option. It also fixes a bug where one could end up with a double set of width/height attributes if other plugins where used at the same time.