### PR TITLE
fix: resolve generator paths on Windows

### DIFF
--- a/packages/markdown-it-image-size/src/env.utils.ts
+++ b/packages/markdown-it-image-size/src/env.utils.ts
@@ -1,3 +1,5 @@
+import { dirname } from "node:path";
+
 type VitePressEnv = {
   path?: string;
 };
@@ -35,7 +37,9 @@ export const getAbsPathFromGeneratorEnv = (
       break;
   }
 
-  return markdownPath
-    ?.substring(0, markdownPath.lastIndexOf("/"))
-    .replace(/\/\.\//g, "/");
+  if (markdownPath === undefined) {
+    return undefined;
+  }
+
+  return dirname(markdownPath.replace(/\\/g, "/")).replace(/\/\.\//g, "/");
 };

--- a/packages/markdown-it-image-size/test/env.utils.test.ts
+++ b/packages/markdown-it-image-size/test/env.utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getAbsPathFromGeneratorEnv } from "../src/env.utils";
+
+describe(getAbsPathFromGeneratorEnv.name, () => {
+  it.each([
+    {
+      name: "POSIX VitePress path",
+      env: { path: "/workspace/docs/blog/post.md" },
+      expected: "/workspace/docs/blog",
+    },
+    {
+      name: "Windows VitePress path",
+      env: { path: String.raw`D:\workspace\docs\blog\post.md` },
+      expected: "D:/workspace/docs/blog",
+    },
+    {
+      name: "POSIX Eleventy path",
+      env: { page: { inputPath: "/workspace/posts/post.md" } },
+      expected: "/workspace/posts",
+    },
+    {
+      name: "Windows Eleventy path",
+      env: {
+        page: {
+          inputPath: String.raw`D:\workspace\posts\post.md`,
+        },
+      },
+      expected: "D:/workspace/posts",
+    },
+  ])("resolves $name", ({ env, expected }) => {
+    expect(getAbsPathFromGeneratorEnv(env)).toBe(expected);
+  });
+
+  it("returns undefined when generator context is unavailable", () => {
+    expect(getAbsPathFromGeneratorEnv(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fix relative image resolution when VitePress or Eleventy provides a Windows-style Markdown path.

## Problem

The plugin previously extracted the Markdown file's parent directory using `lastIndexOf("/")`. Windows paths use backslashes, so paths such as: `D:\workspace\docs\blog\post.md` could resolve to an empty directory. Relative images were then read from the
wrong location, causing the console to report a no such file or directory error.

<img width="807" height="277" alt="image" src="https://github.com/user-attachments/assets/199f9d88-3ba2-4b95-b407-746f9d293f76" />


## Solution

Normalize generator paths to forward slashes and use `path.dirname()` to resolve the parent directory. Existing POSIX path behavior and missing generator context handling remain unchanged.

## Testing

- Added POSIX and Windows path tests for VitePress and Eleventy.
- Added coverage for missing generator context.
- Build, typecheck, and path-related tests pass.